### PR TITLE
Update MathJax CDN and Latex tips

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -55,7 +55,7 @@
         </div>
         <button class="scroll-to-top" id="scroll-to-top"><i class="fa fa-chevron-up"></i></button>
     </div>
-    <script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+    <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML" type="text/javascript"></script>
     <script>
         document.getElementById("scroll-to-top").addEventListener("click", function() {
             window.scrollTo({top: 0, left: 0, behavior: 'smooth'});

--- a/_posts/2020-01-01-Test-page-to-see-how-the-markdown-is-rendered.md
+++ b/_posts/2020-01-01-Test-page-to-see-how-the-markdown-is-rendered.md
@@ -235,15 +235,13 @@ But let's throw in a <b>tag</b>.
 ### Math expressions
 ---
 
-You can write math expressions using the $$\LateX$$ [markup language](https://en.wikipedia.org/wiki/LaTeX) between double dollar signs : \$$...$$. They can be written inline or as a single block.
+You can write math expressions using the $$LateX$$ [markup language](https://en.wikipedia.org/wiki/LaTeX) between double dollar signs : `$$...$$`. They can be written inline or as a single block.
 
-For example,
-
-\$$P(A|B) = \frac{P(B | A)\cdot P(A)}{P(B)}$$ will render as :
+For example, `$$P(A|B) = \frac{P(B | A)\cdot P(A)}{P(B)}$$` will render as:
 
 $$P(A|B) = \frac{P(B | A)\cdot P(A)}{P(B)}$$
 
-Please note that for a math block to be displayed correctly, it needs to be separated by an empty line, above and below. Besides, the pipe character | may conflict with markdown : it is recommended to use \vert instead.
+Please note that for a math block to be displayed correctly, it needs to be separated by an empty line, above and below. Besides, the pipe character `|` may conflict with markdown: it is recommended to use `\vert` instead.
 
 {:#tables}
 ### Tables


### PR DESCRIPTION
Hello, while editing my own version of this fantastic thing, one simple issue I noticed was this: `WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.`

I updated the source for the MathJax script, as well as modified the accompanying LaTeX tips, as there was some rendering issues with them.