### PR TITLE
Fix incorrect file name in setup post

### DIFF
--- a/_posts/2020-03-01-setup.md
+++ b/_posts/2020-03-01-setup.md
@@ -12,7 +12,7 @@ This is going to be a super simple post about how to setup and use this theme fo
 Q. What will it look like when I am done setting it up?
 
 > This is what it should look  (minus the exact essays ofcourse):
-> <img src="/assets/img/end_result.jpg" style="box-shadow: 2px 2px 20px 0 #ddd;"/>
+> <img src="/assets/img/end_result.png" style="box-shadow: 2px 2px 20px 0 #ddd;"/>
 
 
 Now without further ado, let's get started!

--- a/_posts/2020-03-01-setup.md
+++ b/_posts/2020-03-01-setup.md
@@ -11,7 +11,7 @@ This is going to be a super simple post about how to setup and use this theme fo
 {:.boxit}
 Q. What will it look like when I am done setting it up?
 
-> This is what it should look  (minus the exact essays ofcourse):
+> This is what it should look like (minus the exact essays of course):
 > <img src="/assets/img/end_result.png" style="box-shadow: 2px 2px 20px 0 #ddd;"/>
 
 


### PR DESCRIPTION
This is a fix for an incorrect image filename that is being used in the [setup post](https://simply-jekyll.netlify.app/posts/setup)
<img width="737" alt="Screenshot 2021-10-27 at 20 33 40" src="https://user-images.githubusercontent.com/42111513/139125947-f4a1821d-91ba-4d1f-8e78-1c6165410cb5.png">
